### PR TITLE
deal with UNSTABLE builds as well

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/newrelicnotifier/NewRelicDeploymentNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/newrelicnotifier/NewRelicDeploymentNotifier.java
@@ -66,7 +66,7 @@ public class NewRelicDeploymentNotifier extends Notifier {
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         boolean result = true;
 
-        if (build.getResult() == Result.FAILED ||
+        if (build.getResult() == Result.FAILURE ||
             build.getResult() == Result.ABORTED) {
             listener.getLogger().println("Build unsuccessful. Skipping New Relic Deployment notification.");
             return false;

--- a/src/main/java/org/jenkinsci/plugins/newrelicnotifier/NewRelicDeploymentNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/newrelicnotifier/NewRelicDeploymentNotifier.java
@@ -64,32 +64,35 @@ public class NewRelicDeploymentNotifier extends Notifier {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        boolean result = false;
-        if (build.getResult() == Result.SUCCESS) {
-            EnvVars envVars = build.getEnvironment(listener);
-            envVars.overrideAll(build.getBuildVariables());
+        boolean result = true;
 
-            for (DeploymentNotificationBean n : getNotifications()) {
-                UsernamePasswordCredentials credentials = DeploymentNotificationBean.getCredentials(build.getProject(), n.getApiKey(), client.getApiEndpoint());
-                if (credentials == null) {
-                    listener.getLogger().println("Invalid credentials for Application ID: " + n.getApplicationId());
+        if (build.getResult() == Result.FAILED ||
+            build.getResult() == Result.ABORTED) {
+            listener.getLogger().println("Build unsuccessful. Skipping New Relic Deployment notification.");
+            return false;
+        }
+
+        EnvVars envVars = build.getEnvironment(listener);
+        envVars.overrideAll(build.getBuildVariables());
+
+        for (DeploymentNotificationBean n : getNotifications()) {
+            UsernamePasswordCredentials credentials = DeploymentNotificationBean.getCredentials(build.getProject(), n.getApiKey(), client.getApiEndpoint());
+            if (credentials == null) {
+                listener.getLogger().println("Invalid credentials for Application ID: " + n.getApplicationId());
+                result = false;
+            } else {
+                if (client.sendNotification(Secret.toString(credentials.getPassword()),
+                                            n.getApplicationId(),
+                                            n.getDescription(envVars),
+                                            n.getRevision(envVars),
+                                            n.getChangelog(envVars),
+                                            n.getUser(envVars))) {
+                    listener.getLogger().println("Notified New Relic. Application ID: " + n.getApplicationId());
                 } else {
-                    if (client.sendNotification(
-                            Secret.toString(credentials.getPassword()),
-                            n.getApplicationId(),
-                            n.getDescription(envVars),
-                            n.getRevision(envVars),
-                            n.getChangelog(envVars),
-                            n.getUser(envVars))) {
-                        listener.getLogger().println("Notified New Relic. Application ID: " + n.getApplicationId());
-                        result = true;
-                    } else {
-                        listener.getLogger().println("Failed to notify New Relic. Application ID: " + n.getApplicationId());
-                    }
+                    listener.getLogger().println("Failed to notify New Relic. Application ID: " + n.getApplicationId());
+                    result = false;
                 }
             }
-        } else {
-            listener.getLogger().println("Build unsuccessful. Skipping New Relic Deployment notification.");
         }
         return result;
     }


### PR DESCRIPTION
what happens in our case is, that the build is marked UNSTABLE because of some
extra tasks/logic.  currently the plugin would mark this build as FAILED...

i think the issue of the return value can be ambigious...
with multiple notifications, i would probably want the plugin to fail
if any of those notifications failed...  that is what this pull request tries to do...