### PR TITLE
[JENKINS-54405] Fixed two bugs with NewRelic API v2 usage

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/newrelicnotifier/NewRelicDeploymentNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/newrelicnotifier/NewRelicDeploymentNotifier.java
@@ -86,15 +86,17 @@ public class NewRelicDeploymentNotifier extends Notifier {
                 listener.error("Invalid credentials for Application ID: %s", n.getApplicationId());
                 result = false;
             } else {
-                if (client.sendNotification(Secret.toString(credentials.getPassword()),
-                                            n.getApplicationId(),
-                                            n.getDescription(envVars),
-                                            n.getRevision(envVars),
-                                            n.getChangelog(envVars),
-                                            n.getUser(envVars))) {
+                try {
+                    client.sendNotification(Secret.toString(credentials.getPassword()),
+                        n.getApplicationId(),
+                        n.getDescription(envVars),
+                        n.getRevision(envVars),
+                        n.getChangelog(envVars),
+                        n.getUser(envVars));
                     listener.getLogger().println("Notified New Relic. Application ID: " + n.getApplicationId());
-                } else {
+                } catch (IOException e) {
                     listener.error("Failed to notify New Relic. Application ID: %s", n.getApplicationId());
+                    e.printStackTrace(listener.getLogger());
                     result = false;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/newrelicnotifier/api/NewRelicClient.java
+++ b/src/main/java/org/jenkinsci/plugins/newrelicnotifier/api/NewRelicClient.java
@@ -50,11 +50,10 @@ public interface NewRelicClient {
      * @param revision The revision number from your source control system
      * @param changelog A list of changes for this deployment
      * @param user The name of the user/process that triggered this deployment
-     * @return Returns true if notifications was successful
-     * @throws IOException when HttpClient is not able to be closed
+     * @throws IOException when HttpClient is not able to be closed or unexpected status code received
      * @see <a href="https://docs.newrelic.com/docs/apm/apis/requirements/api-key">https://docs.newrelic.com/docs/apm/apis/requirements/api-key</a>
      */
-    boolean sendNotification(
+    void sendNotification(
             String apiKey,
             String applicationId,
             String description,


### PR DESCRIPTION
1. {"error":{"title":"The requested content-type 'text/plain' is not supported."}}
2. {"error":{"title":"missing parameter: deployment"}}
Improved error handling, response body is not swallowed any more

(it took me quite a while to figure out what the issue was)