### PR TITLE
fix: Paged content support for NRclient. Made some refactoring in get…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/newrelicnotifier/api/ApplicationList.java
+++ b/src/main/java/org/jenkinsci/plugins/newrelicnotifier/api/ApplicationList.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.newrelicnotifier.api;
+
+import java.util.List;
+
+public class ApplicationList {
+    
+    private List<Application> applications;
+
+    public ApplicationList(List<Application> applications) {
+        this.applications = applications;
+    }
+
+    public List<Application> getApplications() {
+        return applications;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/newrelicnotifier/api/NewRelicClientImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/newrelicnotifier/api/NewRelicClientImplTest.java
@@ -1,0 +1,85 @@
+package org.jenkinsci.plugins.newrelicnotifier.api;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+public class NewRelicClientImplTest {
+
+    private NewRelicClientStub nrClient;
+    private HttpClientStub httpClient = mock(HttpClientStub.class);
+    
+    @Before
+    public void setup() throws IOException {
+        nrClient = new NewRelicClientStub();
+        nrClient.setHttpClient(httpClient);
+
+    }
+   
+    @SuppressWarnings("unchecked")
+    @Test
+    public void getMultiplePagesApplications() throws ClientProtocolException, IOException {
+        int expectedSize = NewRelicClientImpl.PAGE_SIZE + 50;
+        when(httpClient.execute(any(HttpUriRequest.class), any(ResponseHandler.class)))
+            .thenAnswer(getAnswerForAppSize(expectedSize));
+
+        try {
+            List<Application> apps = nrClient.getApplications("someapikey");
+            assertTrue(apps.size() == expectedSize);
+            verify(httpClient, times(2)).execute(any(HttpUriRequest.class), any(ResponseHandler.class));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void getOnePageOfApplications() throws ClientProtocolException, IOException {
+        int expectedSize = NewRelicClientImpl.PAGE_SIZE - 50;
+        when(httpClient.execute(any(HttpUriRequest.class), any(ResponseHandler.class)))
+            .thenAnswer(getAnswerForAppSize(expectedSize));
+
+        try {
+            List<Application> apps = nrClient.getApplications("someapikey");
+            assertTrue(apps.size() == expectedSize);
+            verify(httpClient).execute(any(HttpUriRequest.class), any(ResponseHandler.class));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    private Answer<ApplicationList> getAnswerForAppSize(final int size) {
+        return new Answer<ApplicationList>() {
+            private int count = 0;
+            private int fullPages = size / NewRelicClientImpl.PAGE_SIZE;
+            private int rest = size % NewRelicClientImpl.PAGE_SIZE;
+            public ApplicationList answer(InvocationOnMock invocation) {
+                if (count++ < fullPages)
+                    return new ApplicationList(getApplicationMocks(NewRelicClientImpl.PAGE_SIZE));
+
+                return new ApplicationList(getApplicationMocks(rest));
+            }
+        };
+    }
+    
+    private List<Application> getApplicationMocks(int size) {
+        List<Application> apps = new LinkedList<>();
+        for (int i = 0; i < size; i++) {
+            apps.add(mock(Application.class));
+        }
+        return apps;
+    }
+    
+}

--- a/src/test/java/org/jenkinsci/plugins/newrelicnotifier/api/NewRelicClientStub.java
+++ b/src/test/java/org/jenkinsci/plugins/newrelicnotifier/api/NewRelicClientStub.java
@@ -25,14 +25,12 @@ package org.jenkinsci.plugins.newrelicnotifier.api;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 
-import java.net.URI;
-
 public class NewRelicClientStub extends NewRelicClientImpl {
 
     private CloseableHttpClient httpClient;
 
     @Override
-    protected CloseableHttpClient getHttpClient(URI url) {
+    protected CloseableHttpClient getHttpClient(String host) {
         return httpClient;
     }
 


### PR DESCRIPTION
Made some changes on the NewRelicClientImpl class. The New Relic API REST returns content paged, with a maximum of 200 objects in the case of the get applications service. I added the paging support to be able to retrieve all elements. In the current version, if you have more than 200 applications, you can't see them all.  Made some refactoring too to the getApplications method and made ApplicationList a public class to add some tests.
You can check [New Relic documentation](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/pagination-api-output)  for more info.